### PR TITLE
render Tags below the content

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ theme:
   # logo: 'logo.png'
   favicon: 'favicon.png'
   language: 'fa'
-  #custom_dir: 'overrides'
+  custom_dir: 'overrides'
   palette:
     scheme: 'slate'
     primary: 'pink'

--- a/overrides/partials/content.html
+++ b/overrides/partials/content.html
@@ -1,0 +1,32 @@
+<!-- Actions -->
+{% include "partials/actions.html" %}
+
+<!--
+  Hack: check whether the content contains a h1 headline. If it doesn't, the
+  page title (or respectively site name) is used as the main headline.
+-->
+{% if "\x3ch1" not in page.content %}
+  <h1>{{ page.title | d(config.site_name, true)}}</h1>
+{% endif %}
+
+<!-- Page content -->
+{{ page.content }}
+
+<!-- Tags -->
+{% if "material/tags" in config.plugins and tags %}
+  {% include "partials/tags.html" %}
+{% endif %}
+
+<!-- Source file information -->
+{% if page.meta and (
+  page.meta.git_revision_date_localized or
+  page.meta.revision_date
+) %}
+  {% include "partials/source-file.html" %}
+{% endif %}
+
+<!-- Was this page helpful? -->
+{% include "partials/feedback.html" %}
+
+<!-- Comment system -->
+{% include "partials/comments.html" %}


### PR DESCRIPTION
Tags are rendered below the actual content of the document

- useful link
  - https://squidfunk.github.io/mkdocs-material/customization
  - https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/partials/content.html
